### PR TITLE
fix bug with exeption private method set_output' called for #<LiveKit…

### DIFF
--- a/lib/livekit/egress_service_client.rb
+++ b/lib/livekit/egress_service_client.rb
@@ -39,7 +39,7 @@ module LiveKit
         audio_only: audio_only,
         video_only: video_only,
       )
-      self.set_output(request, output)
+      set_output(request, output)
       self.rpc(
         :StartRoomCompositeEgress,
         request,
@@ -66,7 +66,7 @@ module LiveKit
         preset: preset,
         advanced: advanced,
       )
-      self.set_output(request, output)
+      set_output(request, output)
       self.rpc(
         :StartParticipantEgress,
         request,
@@ -94,7 +94,7 @@ module LiveKit
         audio_track_id: audio_track_id,
         video_track_id: video_track_id,
       )
-      self.set_output(request, output)
+      set_output(request, output)
       self.rpc(
         :StartTrackCompositeEgress,
         request,
@@ -147,7 +147,7 @@ module LiveKit
         video_only: video_only,
         await_start_signal: await_start_signal,
       )
-      self.set_output(request, output)
+      set_output(request, output)
       self.rpc(
         :StartWebEgress,
         request,


### PR DESCRIPTION
fix issue #39 (https://github.com/livekit/server-sdk-ruby/issues/39)